### PR TITLE
Fix /entrypoint.sh: command substitution: line 51: syntax error near unexpected token `||

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -50,7 +50,7 @@ declare -r AUTOSCALING_GROUP_NAME=$(
         --region $REGION \
         --filters "Name=resource-id,Values=$INSTANCE_ID" \
                   "Name=key,Values=aws:autoscaling:groupName" \
-        | jq -r '.Tags[0].Value'
+        | jq -r '.Tags[0].Value' \
         || echo "AutoDetectionFailed"
     )
 


### PR DESCRIPTION
- Fix /entrypoint.sh: command substitution: line 51: syntax error near unexpected token `||