### PR TITLE
Ship v0.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+0.0.3 (2019-04-15)
+==================
+
+* Detect the 'Error response from daemon: conflict: unable to delete' error. (#5)
+
 0.0.2 (2019-02-24)
 ==================
 


### PR DESCRIPTION
* Detect the 'Error response from daemon: conflict: unable to delete' error. (#5)