### PR TITLE
[DO NOT MERGE until the pre-release become stable] 0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,23 @@
+0.1.0.pre (2019-05-09)
+======================
+
+**This release breaks backwards compatibility!!**
+
+* Add new options.
+    * `TERMINATE_STALE_EC2`
+    * `ATTRIBUTES_FOR_STALE_EC2`
+    * `ENTER_STANDBY_STALE_EC2`
+    * `DETACH_STALE_EC2`
+* Increase IAMs this image uses.
+    * `ecs:ListContainerInstances`
+    * `ecs:PutAttributes`
+    * `autoscaling:EnterStandby`
+    * `autoscaling:DetachInstances`
+* Change the way to write codes.
+    * Use double bracket(`[[]]`) for conditions.
+    * Use `${var}` way instead of `$var` for variables in the context of arguments.
+    * Change log massages and slack messages.
+
 0.0.4 (2019-06-23)
 ==================
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Docker Image for ECS to terminate a stale container instance that belongs to a a
     - `Error response from daemon: conflict: unable to delete`
     - `Duplicate ENI attachment message`
 1. Notify the detection to Slack if `SLACK_URL` is specified.
+1. Execute `aws ecs put-attributes --cluster $ECS_CLUSTER --attributes $ATTRIBUTES` if `ATTRIBUTES_FOR_STALE_EC2` is specified.
 1. Execute `aws autoscaling terminate-instance-in-auto-scaling-group --instance-id $INSTANCE_ID --no-should-decrement-desired-capacity` if `TERMINATE_STALE_EC2=true`
 
 # Environment Variables
@@ -20,6 +21,7 @@ Docker Image for ECS to terminate a stale container instance that belongs to a a
 - `POLLING_INTERVAL`: Interval seconds for polling. (default: `1`)
 - `DUPLICATE_ENI_ATTACHMENT_PER_HOUR_THRESHOLD`: Threshold for number of 'Duplicate ENI attachment message' per hour. (default: `50`)
 - `TERMINATE_STALE_EC2`: Terminate stale ec2 or not. (default: `true`)
+- `ATTRIBUTES_FOR_STALE_EC2`: Attributes for stale ec2. This must be 'key=value' strings delimited by a space. (default: empty string)
 - `INSTANCE_IDENTITY_URL`: The URL to get the instance identity. (default: `"http://169.254.169.254/latest/dynamic/instance-identity/document"`)
 - `SLACK_URL`: Slack webhook url for the notification. (optional)
 - `SLACK_ADDITIONAL_MESSAGE`: Slack addtional message for the notification. (optional)

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Docker Image for ECS to terminate a stale container instance that belongs to a a
 1. Notify the detection to Slack if `SLACK_URL` is specified.
 1. Execute `aws ecs put-attributes --cluster $ECS_CLUSTER --attributes $ATTRIBUTES` if `ATTRIBUTES_FOR_STALE_EC2` is specified.
 1. Execute `aws autoscaling terminate-instance-in-auto-scaling-group --instance-id $INSTANCE_ID --no-should-decrement-desired-capacity` if `TERMINATE_STALE_EC2=true`
+1. Execute `aws autoscaling detach-instances --instance-id $INSTANCE_ID --auto-scaling-group-name $AUTOSCALING_GROUP_NAME --no-should-decrement-desired-capacity` if `DETACH_STALE_EC2=true` and `TERMINATE_STALE_EC2=false` 
 
 # Environment Variables
 
@@ -21,6 +22,7 @@ Docker Image for ECS to terminate a stale container instance that belongs to a a
 - `POLLING_INTERVAL`: Interval seconds for polling. (default: `1`)
 - `DUPLICATE_ENI_ATTACHMENT_PER_HOUR_THRESHOLD`: Threshold for number of 'Duplicate ENI attachment message' per hour. (default: `50`)
 - `TERMINATE_STALE_EC2`: Terminate stale ec2 or not. (default: `true`)
+- `DETACH_STALE_EC2`: Detach stale ec2 or not. Ignore this option `TERMINATE_STALE_EC2=true` (default: `false`) 
 - `ATTRIBUTES_FOR_STALE_EC2`: Attributes for stale ec2. This must be 'key=value' strings delimited by a space. (default: empty string)
 - `INSTANCE_IDENTITY_URL`: The URL to get the instance identity. (default: `"http://169.254.169.254/latest/dynamic/instance-identity/document"`)
 - `SLACK_URL`: Slack webhook url for the notification. (optional)

--- a/README.md
+++ b/README.md
@@ -12,13 +12,14 @@ Docker Image for ECS to terminate a stale container instance that belongs to a a
     - `Error response from daemon: conflict: unable to delete`
     - `Duplicate ENI attachment message`
 1. Notify the detection to Slack if `SLACK_URL` is specified.
-1. Execute `aws autoscaling terminate-instance-in-auto-scaling-group --instance-id $INSTANCE_ID --no-should-decrement-desired-capacity`
+1. Execute `aws autoscaling terminate-instance-in-auto-scaling-group --instance-id $INSTANCE_ID --no-should-decrement-desired-capacity` if `TERMINATE_STALE_EC2=true`
 
 # Environment Variables
 
 - `POLLING_MAX_ATTEMPTS`: Max number of attempts for polling. (default: `60`)
 - `POLLING_INTERVAL`: Interval seconds for polling. (default: `1`)
 - `DUPLICATE_ENI_ATTACHMENT_PER_HOUR_THRESHOLD`: Threshold for number of 'Duplicate ENI attachment message' per hour. (default: `50`)
+- `TERMINATE_STALE_EC2`: Terminate stale ec2 or not. (default: `true`)
 - `INSTANCE_IDENTITY_URL`: The URL to get the instance identity. (default: `"http://169.254.169.254/latest/dynamic/instance-identity/document"`)
 - `SLACK_URL`: Slack webhook url for the notification. (optional)
 - `SLACK_ADDITIONAL_MESSAGE`: Slack addtional message for the notification. (optional)

--- a/README.md
+++ b/README.md
@@ -13,8 +13,9 @@ Docker Image for ECS to terminate a stale container instance that belongs to a a
     - `Duplicate ENI attachment message`
 1. Notify the detection to Slack if `SLACK_URL` is specified.
 1. Execute `aws ecs put-attributes --cluster $ECS_CLUSTER --attributes $ATTRIBUTES` if `ATTRIBUTES_FOR_STALE_EC2` is specified.
-1. Execute `aws autoscaling terminate-instance-in-auto-scaling-group --instance-id $INSTANCE_ID --no-should-decrement-desired-capacity` if `TERMINATE_STALE_EC2=true`
-1. Execute `aws autoscaling detach-instances --instance-id $INSTANCE_ID --auto-scaling-group-name $AUTOSCALING_GROUP_NAME --no-should-decrement-desired-capacity` if `DETACH_STALE_EC2=true` and `TERMINATE_STALE_EC2=false` 
+1. Execute `aws autoscaling terminate-instance-in-auto-scaling-group --instance-id $INSTANCE_ID --no-should-decrement-desired-capacity` if `TERMINATE_STALE_EC2=true`.
+1. Execute `aws autoscaling detach-instances --instance-id $INSTANCE_ID --auto-scaling-group-name $AUTOSCALING_GROUP_NAME --no-should-decrement-desired-capacity` if `ENTER_STANDBY_STALE_EC2=true` and `TERMINATE_STALE_EC2=false`.
+1. Execute `aws autoscaling detach-instances --instance-id $INSTANCE_ID --auto-scaling-group-name $AUTOSCALING_GROUP_NAME --no-should-decrement-desired-capacity` if `DETACH_STALE_EC2=true` and `TERMINATE_STALE_EC2=false`. 
 
 # Environment Variables
 
@@ -22,6 +23,7 @@ Docker Image for ECS to terminate a stale container instance that belongs to a a
 - `POLLING_INTERVAL`: Interval seconds for polling. (default: `1`)
 - `DUPLICATE_ENI_ATTACHMENT_PER_HOUR_THRESHOLD`: Threshold for number of 'Duplicate ENI attachment message' per hour. (default: `50`)
 - `TERMINATE_STALE_EC2`: Terminate stale ec2 or not. (default: `true`)
+- `ENTER_STANDBY_STALE_EC2`: Enter standby stale ec2 or not. Ignore this option `TERMINATE_STALE_EC2=true` (default: `false`)
 - `DETACH_STALE_EC2`: Detach stale ec2 or not. Ignore this option `TERMINATE_STALE_EC2=true` (default: `false`) 
 - `ATTRIBUTES_FOR_STALE_EC2`: Attributes for stale ec2. This must be 'key=value' strings delimited by a space. (default: empty string)
 - `INSTANCE_IDENTITY_URL`: The URL to get the instance identity. (default: `"http://169.254.169.254/latest/dynamic/instance-identity/document"`)

--- a/README.md
+++ b/README.md
@@ -32,11 +32,19 @@ Docker Image for ECS to terminate a stale container instance that belongs to a a
 - `SLACK_CHANNEL`: Slack channel for the notification. (optional)
 - `SLACK_ICON_EMOJI`: Slack icon emoji for the notification. (optional)
 
-# Issues that this repositry concerns
+# Issues that this repository concerns
 
 - [amazon-ecs-agent#1698 Docker corrupted](https://github.com/aws/amazon-ecs-agent/issues/1698)
 - [amazon-ecs-agent#1667 One task prevents from all of the other in instance to change from PENDING to RUNNING](https://github.com/aws/amazon-ecs-agent/issues/1667)
 - [amazon-ecs-agent#1980 Cleanup is not working when ECS mamanged image is running in non-managed container](https://github.com/aws/amazon-ecs-agent/issues/1980)
+
+# IAM Privileges
+- (required) `ec2:DescribeTags`
+- (optional) `ecs:ListContainerInstances`
+- (optional) `ecs:PutAttributes`
+- (optional) `autoscaling:TerminateInstanceInAutoScalingGroup`
+- (optional) `autoscaling:EnterStandby`
+- (optional) `autoscaling:DetachInstances`
 
 # Example
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -22,7 +22,7 @@ function __error_log() {
     __log error "${1:-}" 1>&2
 }
 
-__info_log "This script polls ecs-agent logs to detect the ecs container instance stale state. When the state is detected, this script terminates the instance."
+__info_log "This script polls ecs-agent logs to detect the ecs container instance stale state. When the state is detected, this script can do some actions to the instance."
 __info_log "See https://github.com/civitaspo/ecs-stale-ec2-rescaler for more information."
 
 # Declare variables

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -132,7 +132,15 @@ while true; do
     sleep $POLLING_INTERVAL
 done
 
-declare -r MESSAGE="Detect stale state:[$STALE_STATE_CAUSE], so terminate $INSTANCE_ID in asg:$AUTOSCALING_GROUP_NAME."
+if [ "$TERMINATE_STALE_EC2" = true -a "${#ATTRIBUTES_FOR_AWSCLI[@]}" -ne 0 ]; then
+    declare -r MESSAGE="Detect stale state:[$STALE_STATE_CAUSE], so put attributes[$ATTRIBUTES_FOR_STALE_EC2] and terminate $INSTANCE_ID in asg:$AUTOSCALING_GROUP_NAME."
+elif [ "$TERMINATE_STALE_EC2" = true ]; then
+    declare -r MESSAGE="Detect stale state:[$STALE_STATE_CAUSE], so terminate $INSTANCE_ID in asg:$AUTOSCALING_GROUP_NAME."
+elif [ "${#ATTRIBUTES_FOR_AWSCLI[@]}" -ne 0 ]; then
+    declare -r MESSAGE="Detect stale state:[$STALE_STATE_CAUSE], so put attributes[$ATTRIBUTES_FOR_STALE_EC2] to $INSTANCE_ID in asg:$AUTOSCALING_GROUP_NAME."
+else
+    declare -r MESSAGE="Detect stale state:[$STALE_STATE_CAUSE], but do nothing to $INSTANCE_ID in asg:$AUTOSCALING_GROUP_NAME."
+fi
 declare -r SLACK_MESSAGE=":hammer_and_wrench: $MESSAGE $SLACK_ADDITIONAL_MESSAGE"
 __warn_log "$MESSAGE"
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -55,6 +55,13 @@ declare -r AUTOSCALING_GROUP_NAME=$(
         || echo "AutoDetectionFailed"
     )
 
+declare -r  TERMINATE_STALE_EC2=${TERMINATE_STALE_EC2:-true}
+if [ "$TERMINATE_STALE_EC2" = true ]; then
+    __info_log "Set TERMINATE_STALE_EC2=true"
+else
+    __info_log "Set TERMINATE_STALE_EC2=false"
+fi
+
 declare -r SLACK_URL=${SLACK_URL:-}
 declare -r SLACK_ADDITIONAL_MESSAGE=${SLACK_ADDITIONAL_MESSAGE:-}
 declare -r SLACK_CHANNEL=${SLACK_CHANNEL:-}
@@ -99,10 +106,12 @@ if [ ! -z "$SLACK_URL" ]; then
 fi
 
 # Terminate the container instance.
-aws autoscaling terminate-instance-in-auto-scaling-group \
-    --instance-id $INSTANCE_ID \
-    --no-should-decrement-desired-capacity \
-    --region $REGION
+if [ "$TERMINATE_STALE_EC2" = true ]; then
+    aws autoscaling terminate-instance-in-auto-scaling-group \
+        --instance-id $INSTANCE_ID \
+        --no-should-decrement-desired-capacity \
+        --region $REGION
+fi
 
 # Sleep for 200 seconds to prevent this script from looping.
 # The instance should be terminated by the end of the sleep.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -33,40 +33,40 @@ declare -ir DUPLICATE_ENI_ATTACHMENT_PER_HOUR_THRESHOLD=${DUPLICATE_ENI_ATTACHME
 
 declare -r INSTANCE_IDENTITY_URL=${INSTANCE_IDENTITY_URL:-http://169.254.169.254/latest/dynamic/instance-identity/document}
 declare -i num_attempts=0
-while [ -z "$(curl -s $INSTANCE_IDENTITY_URL | jq -r .instanceId)" ]; do
+while [[ -z "$(curl -s ${INSTANCE_IDENTITY_URL} | jq -r .instanceId)" ]]; do
     if ((num_attempts == POLLING_MAX_ATTEMPTS)); then
-        __error_log "Max attpempts(=$POLLING_MAX_ATTEMPTS) is exceeded because $INSTANCE_IDENTITY_URL did not become available."
+        __error_log "Max attempts(=$POLLING_MAX_ATTEMPTS) is exceeded because $INSTANCE_IDENTITY_URL did not become available."
         exit 1
     fi
-    __info_log "Wait until $INSTANCE_IDENTITY_URL become available. (attpempts: $((num_attempts++))/$POLLING_MAX_ATTEMPTS)"
-    sleep $POLLING_INTERVAL
+    __info_log "Wait until $INSTANCE_IDENTITY_URL become available. (attempts: $((num_attempts++))/$POLLING_MAX_ATTEMPTS)"
+    sleep ${POLLING_INTERVAL}
 done
 unset num_attempts
 
 declare -r INSTANCE_ID=$(curl -s ${INSTANCE_IDENTITY_URL} | jq -r .instanceId)
-declare -r REGION=$(curl -s $INSTANCE_IDENTITY_URL | jq -r .region)
+declare -r REGION=$(curl -s ${INSTANCE_IDENTITY_URL} | jq -r .region)
 declare -r AUTOSCALING_GROUP_NAME=$(
     aws ec2 describe-tags \
-        --region $REGION \
+        --region ${REGION} \
         --filters "Name=resource-id,Values=$INSTANCE_ID" \
                   "Name=key,Values=aws:autoscaling:groupName" \
         | jq -r '.Tags[0].Value'
     )
-if [ -z "$AUTOSCALING_GROUP_NAME" ]; then
+if [[ -z "$AUTOSCALING_GROUP_NAME" ]]; then
     __error_log "Unable to fetch the autoscaling group that ec2:$INSTANCE_ID joins in."
     exit 1
 fi
 
 declare -r  TERMINATE_STALE_EC2=${TERMINATE_STALE_EC2:-true}
-if [ "$TERMINATE_STALE_EC2" = true ]; then
+if [[ "$TERMINATE_STALE_EC2" = true ]]; then
     __info_log "Set TERMINATE_STALE_EC2=true"
 else
     __info_log "Set TERMINATE_STALE_EC2=false"
 fi
 
 declare -r  ENTER_STANDBY_STALE_EC2=${ENTER_STANDBY_STALE_EC2:-false}
-if [ "$ENTER_STANDBY_STALE_EC2" = true ]; then
-    if [ "$TERMINATE_STALE_EC2" = true ]; then
+if [[ "$ENTER_STANDBY_STALE_EC2" = true ]]; then
+    if [[ "$TERMINATE_STALE_EC2" = true ]]; then
         __warn_log "Ignore ENTER_STANDBY_STALE_EC2 setting because of TERMINATE_STALE_EC2=true."
     else
         __info_log "Set ENTER_STANDBY_STALE_EC2=true"
@@ -76,8 +76,8 @@ else
 fi
 
 declare -r  DETACH_STALE_EC2=${DETACH_STALE_EC2:-false}
-if [ "$DETACH_STALE_EC2" = true ]; then
-    if [ "$TERMINATE_STALE_EC2" = true ]; then
+if [[ "$DETACH_STALE_EC2" = true ]]; then
+    if [[ "$TERMINATE_STALE_EC2" = true ]]; then
         __warn_log "Ignore DETACH_STALE_EC2 setting because of TERMINATE_STALE_EC2=true."
     else
         __info_log "Set DETACH_STALE_EC2=true"
@@ -86,31 +86,31 @@ else
     __info_log "Set TERMINATE_STALE_EC2=false"
 fi
 
-declare -r  ECS_CLUSTER="$(curl -s $ECS_CONTAINER_METADATA_URI/task | jq -r .Cluster)"
-if [ -z "$ECS_CLUSTER" ]; then
+declare -r  ECS_CLUSTER="$(curl -s ${ECS_CONTAINER_METADATA_URI}/task | jq -r .Cluster)"
+if [[ -z "$ECS_CLUSTER" ]]; then
     __error_log "Unable to fetch the name of the cluster."
     exit 1
 fi
 declare -r  ATTRIBUTES_FOR_STALE_EC2="${ATTRIBUTES_FOR_STALE_EC2:-}"
 declare -ir MAX_ATTRIBUTES=${MAX_ATTRIBUTES:-10}  # AWS Restriction
 declare -a  ATTRIBUTES_FOR_AWSCLI=()
-if [ -n "$ATTRIBUTES_FOR_STALE_EC2" ]; then
+if [[ -n "$ATTRIBUTES_FOR_STALE_EC2" ]]; then
     declare -r container_instance_arn=$(
         aws ecs list-container-instances \
-            --region $REGION \
-            --cluster $ECS_CLUSTER \
+            --region ${REGION} \
+            --cluster ${ECS_CLUSTER} \
             --filter "ec2InstanceId==$INSTANCE_ID" \
             | jq -r '.containerInstanceArns[0]'
         )
-    if [ -z "container_instance_arn" ]; then
+    if [[ -z "container_instance_arn" ]]; then
         __error_log "Unable to fetch the arn of the container instance(ec2 id: $INSTANCE_ID)."
         exit 1
     fi
     __info_log "Container Instance ARN: $container_instance_arn"
 
     declare -i num_attrs=0
-    for attr_kv in $ATTRIBUTES_FOR_STALE_EC2; do
-        if [ "$((++num_attrs))" -gt $MAX_ATTRIBUTES ]; then
+    for attr_kv in ${ATTRIBUTES_FOR_STALE_EC2}; do
+        if [[ "$((++num_attrs))" -gt ${MAX_ATTRIBUTES} ]]; then
             __error_log "You can specify up to $MAX_ATTRIBUTES attributes in a single call."
             exit 1
         fi
@@ -151,7 +151,7 @@ while true; do
             break 2
         fi
     done
-    sleep $POLLING_INTERVAL
+    sleep ${POLLING_INTERVAL}
 done
 
 declare -a actions=()
@@ -177,7 +177,7 @@ unset actions
 declare -r SLACK_MESSAGE=":hammer_and_wrench: $MESSAGE $SLACK_ADDITIONAL_MESSAGE"
 __warn_log "$MESSAGE"
 
-if [ ! -z "$SLACK_URL" ]; then
+if [[ ! -z "$SLACK_URL" ]]; then
     curl -X POST \
          -H 'Content-type: application/json' \
          --data "
@@ -188,37 +188,37 @@ if [ ! -z "$SLACK_URL" ]; then
                  \"username\":\"$APP_NAME\"
              }
              " \
-         $SLACK_URL
+         ${SLACK_URL}
 fi
 
 # Put attributes
-if [ "${#ATTRIBUTES_FOR_AWSCLI[@]}" -ne 0 ]; then
+if [[ "${#ATTRIBUTES_FOR_AWSCLI[@]}" -ne 0 ]]; then
     aws ecs put-attributes \
-        --cluster $ECS_CLUSTER \
+        --cluster ${ECS_CLUSTER} \
         --attributes ${ATTRIBUTES_FOR_AWSCLI[@]} \
-        --region $REGION
+        --region ${REGION}
 fi
 
 # Do actions to the container instance.
 if [[ "$TERMINATE_STALE_EC2" = true ]]; then
     aws autoscaling terminate-instance-in-auto-scaling-group \
-        --instance-id $INSTANCE_ID \
+        --instance-id ${INSTANCE_ID} \
         --no-should-decrement-desired-capacity \
-        --region $REGION
+        --region ${REGION}
 else
     if [[ "$ENTER_STANDBY_STALE_EC2" = true ]]; then
         aws autoscaling enter-standby \
-            --instance-ids $INSTANCE_ID \
-            --auto-scaling-group-name $AUTOSCALING_GROUP_NAME \
+            --instance-ids ${INSTANCE_ID} \
+            --auto-scaling-group-name ${AUTOSCALING_GROUP_NAME} \
             --no-should-decrement-desired-capacity \
-            --region $REGION
+            --region ${REGION}
     fi
     if [[ "$DETACH_STALE_EC2" = true ]]; then
         aws autoscaling detach-instances \
-            --instance-ids $INSTANCE_ID \
-            --auto-scaling-group-name $AUTOSCALING_GROUP_NAME \
+            --instance-ids ${INSTANCE_ID} \
+            --auto-scaling-group-name ${AUTOSCALING_GROUP_NAME} \
             --no-should-decrement-desired-capacity \
-            --region $REGION
+            --region ${REGION}
     fi
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -81,14 +81,12 @@ if [ -n "$ATTRIBUTES_FOR_STALE_EC2" ]; then
     if [ -z "container_instance_arn" ]; then
         __error_log "Unable to fetch the arn of the container instance(ec2 id: $INSTANCE_ID)."
         exit 1
-    else
-        __info_log "Container Instance ARN: $container_instance_arn"
     fi
+    __info_log "Container Instance ARN: $container_instance_arn"
 
     declare -i num_attrs=0
     for attr_kv in $ATTRIBUTES_FOR_STALE_EC2; do
-        let num_attrs++
-        if [ "$num_attrs" -gt $MAX_ATTRIBUTES ]; then
+        if [ "$((++num_attrs))" -gt $MAX_ATTRIBUTES ]; then
             __error_log "You can specify up to $MAX_ATTRIBUTES attributes in a single call."
             exit 1
         fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -78,7 +78,7 @@ if [ -n "$ATTRIBUTES_FOR_STALE_EC2" ]; then
             --filter "ec2InstanceId==$INSTANCE_ID" \
             | jq -r '.containerInstanceArns[0]'
         )
-    if [ -z "CONTAINER_INSTANCE_ARN" ]; then
+    if [ -z "container_instance_arn" ]; then
         __error_log "Unable to fetch the arn of the container instance(ec2 id: $INSTANCE_ID)."
         exit 1
     else

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -38,7 +38,7 @@ while [ -z "$(curl -s $INSTANCE_IDENTITY_URL | jq -r .instanceId)" ]; do
         __error_log "Max attpempts(=$POLLING_MAX_ATTEMPTS) is exceeded because $INSTANCE_IDENTITY_URL did not become available."
         exit 1
     fi
-    __info_log "Wait until $INSTANCE_IDENTITY_URL become available. ($((num_attempts++))s)"
+    __info_log "Wait until $INSTANCE_IDENTITY_URL become available. (attpempts: $((num_attempts++))/$POLLING_MAX_ATTEMPTS)"
     sleep $POLLING_INTERVAL
 done
 unset num_attempts

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -71,7 +71,7 @@ declare -r  ATTRIBUTES_FOR_STALE_EC2="${ATTRIBUTES_FOR_STALE_EC2:-}"
 declare -ir MAX_ATTRIBUTES=${MAX_ATTRIBUTES:-10}  # AWS Restriction
 declare -a  ATTRIBUTES_FOR_AWSCLI=()
 if [ -n "$ATTRIBUTES_FOR_STALE_EC2" ]; then
-    declare container_instance_arn=$(
+    declare -r container_instance_arn=$(
         aws ecs list-container-instances \
             --region $REGION \
             --cluster $ECS_CLUSTER \


### PR DESCRIPTION
**This release breaks backwards compatibility!!**

* Add new options.
    * `TERMINATE_STALE_EC2`
    * `ATTRIBUTES_FOR_STALE_EC2`
    * `ENTER_STANDBY_STALE_EC2`
    * `DETACH_STALE_EC2`
* Increase IAMs this image uses.
    * `ecs:ListContainerInstances`
    * `ecs:PutAttributes`
    * `autoscaling:EnterStandby`
    * `autoscaling:DetachInstances`
* Change the way to write codes.
    * Use double bracket(`[[]]`) for conditions.
    * Use `${var}` way instead of `$var` for variables in the context of arguments.
    * Change log massages and slack messages.
