### PR TITLE
Support ecs-agent 1.28.0 error message.

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -71,7 +71,7 @@ while true; do
         STALE_STATE_CAUSE="'Error response from daemon: conflict: unable to delete' is occurred"
         break
     fi
-    for n in $(grep 'Duplicate ENI attachment message' /var/log/ecs/ecs-agent.log* | cut -f2 -d: | sort -n | uniq -c |  xargs -n2 echo | cut -f1 -d' '); do
+    for n in $(grep -P 'Duplicate (ENI|task-eni) attachment message' /var/log/ecs/ecs-agent.log* | cut -f2 -d: | sort -n | uniq -c |  xargs -n2 echo | cut -f1 -d' '); do
         if ((n > DUPLICATE_ENI_ATTACHMENT_PER_HOUR_THRESHOLD)); then
             STALE_STATE_CAUSE="'Duplicate ENI attachment message' count exceeds $DUPLICATE_ENI_ATTACHMENT_PER_HOUR_THRESHOLD/h"
             break 2


### PR DESCRIPTION
* Support ecs-agent 1.28.0 error message about `Duplicate task-eni attachment message`.
    * ref. https://github.com/aws/amazon-ecs-agent/blob/v1.28.0/agent/acs/handler/attach_eni_handler_common.go#L72