### PR TITLE
Ship v0.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+0.0.4 (2019-06-23)
+==================
+
+* Support ecs-agent 1.28.0 error message about `Duplicate task-eni attachment message`. (#9)
+
 0.0.3 (2019-04-15)
 ==================
 


### PR DESCRIPTION
* Support ecs-agent 1.28.0 error message about `Duplicate task-eni attachment message`. (#9)