### PR TITLE
Enable to specify ignore message when matches `Error getting message from ws backend`

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Docker Image for ECS to terminate a stale container instance that belongs to a a
 - `SLACK_ADDITIONAL_MESSAGE`: Slack addtional message for the notification. (optional)
 - `SLACK_CHANNEL`: Slack channel for the notification. (optional)
 - `SLACK_ICON_EMOJI`: Slack icon emoji for the notification. (optional)
+- `IGNORE_MESSAGE_IN_WS_BACKEND`: The string to ignore in the message that matches `Error getting message from ws backend`. (optional)
 
 # Issues that this repositry concerns
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -62,8 +62,16 @@ declare -r SLACK_ICON_EMOJI=${SLACK_ICON_EMOJI:-}
 
 __info_log "Polling until errors are catched."
 declare STALE_STATE_CAUSE=""
+declare -r IGNORE_MESSAGE_IN_WS_BACKEND=${IGNORE_MESSAGE_IN_WS_BACKEND:-}
+
 while true; do
-    if ls /var/log/ecs/ecs-agent.log* | sort -n | tail -n1 | xargs -I{} grep -r "Error getting message from ws backend" {} >/dev/null; then
+    if [[ -z ${IGNORE_MESSAGE_IN_WS_BACKEND} ]]; then
+        declare -ir ERR_WS_BACKEND_CNT=$(ls /var/log/ecs/ecs-agent.log* | sort -n | tail -n1 | xargs -I{} grep -r "Error getting message from ws backend" {} | wc -l)
+    else
+        declare -ir ERR_WS_BACKEND_CNT=$(ls /var/log/ecs/ecs-agent.log* | sort -n | tail -n1 | xargs -I{} grep -r "Error getting message from ws backend" {} | grep -v ${IGNORE_MESSAGE_IN_WS_BACKEND} | wc -l)
+    fi
+
+    if ((ERR_WS_BACKEND_CNT > 0)); then
         STALE_STATE_CAUSE="'Error getting message from ws backend' is occurred"
         break
     fi


### PR DESCRIPTION
This feature is that it's enable to specify ignore message when matches `Error getting message from ws backend`.

In the case of the following issue, although the message was matched, there are cases that container will run successfully.

refs: https://github.com/aws/amazon-ecs-agent/issues/2112

Under the condition(instance type is c5, m5, and r5 with `ecs-stale-ec2-rescaler`), the instance is terminated immediately after start.
So I want to the feature to avoid this situation.