### PR TITLE
Bugfix. ERR_WS_BACKEND_CNT must not be readonly.

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -66,9 +66,9 @@ declare -r IGNORE_MESSAGE_IN_WS_BACKEND=${IGNORE_MESSAGE_IN_WS_BACKEND:-}
 
 while true; do
     if [[ -z ${IGNORE_MESSAGE_IN_WS_BACKEND} ]]; then
-        declare -ir ERR_WS_BACKEND_CNT=$(ls /var/log/ecs/ecs-agent.log* | sort -n | tail -n1 | xargs -I{} grep -r "Error getting message from ws backend" {} | wc -l)
+        declare -i ERR_WS_BACKEND_CNT=$(ls /var/log/ecs/ecs-agent.log* | sort -n | tail -n1 | xargs -I{} grep -r "Error getting message from ws backend" {} | wc -l)
     else
-        declare -ir ERR_WS_BACKEND_CNT=$(ls /var/log/ecs/ecs-agent.log* | sort -n | tail -n1 | xargs -I{} grep -r "Error getting message from ws backend" {} | grep -v ${IGNORE_MESSAGE_IN_WS_BACKEND} | wc -l)
+        declare -i ERR_WS_BACKEND_CNT=$(ls /var/log/ecs/ecs-agent.log* | sort -n | tail -n1 | xargs -I{} grep -r "Error getting message from ws backend" {} | grep -v ${IGNORE_MESSAGE_IN_WS_BACKEND} | wc -l)
     fi
 
     if ((ERR_WS_BACKEND_CNT > 0)); then


### PR DESCRIPTION
## Summary

`ERR_WS_BACKEND_CNT` should not be readonly variable.  Fix this error.

```
/entrypoint.sh: line 71: declare: ERR_WS_BACKEND_CNT: readonly variable
```